### PR TITLE
fix: use Access-Control-Allow-Methods to specify allowed request methods

### DIFF
--- a/Examples_from_plants_database/Flask-CORS-Example-1/flaskr/__init__.py
+++ b/Examples_from_plants_database/Flask-CORS-Example-1/flaskr/__init__.py
@@ -15,7 +15,7 @@ def create_app(test_config=None):
             "Access-Control-Allow-Headers", "Content-Type, Authorization"
         )
         response.headers.add(
-            "Access-Control-Allow-Headers", "GET, POST, PATCH, DELETE, OPTION"
+            "Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTION"
         )
         return response
 


### PR DESCRIPTION
fix: use Access-Control-Allow-Methods to specify allowed request methods